### PR TITLE
DualSense TouchPad conversion fix

### DIFF
--- a/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
@@ -697,7 +697,7 @@ namespace DS4Windows.InputDevices
                     cState.TrackPadTouch0.X = (short)(((ushort)(inputReport[35+reportOffset] & 0x0f) << 8) | (ushort)(inputReport[34+reportOffset]));
                     cState.TrackPadTouch0.Y = (short)(((ushort)(inputReport[36+reportOffset]) << 4) | ((ushort)(inputReport[35+reportOffset] & 0xf0) >> 4));
 
-                    cState.TrackPadTouch0.RawTrackingNum = inputReport[37+reportOffset];
+                    cState.TrackPadTouch1.RawTrackingNum = inputReport[37+reportOffset];
                     cState.TrackPadTouch1.Id = (byte)(inputReport[37+reportOffset] & 0x7f);
                     cState.TrackPadTouch1.IsActive = (inputReport[37+reportOffset] & 0x80) == 0;
                     cState.TrackPadTouch1.X = (short)(((ushort)(inputReport[39+reportOffset] & 0x0f) << 8) | (ushort)(inputReport[38+reportOffset]));

--- a/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
+++ b/DS4Windows/DS4Library/InputDevices/DualSenseDevice.cs
@@ -710,7 +710,7 @@ namespace DS4Windows.InputDevices
                         // don't seem to contain relevant data. ds4drv does not use them either.
                         int touchOffset = 0;
 
-                        cState.TouchPacketCounter = inputReport[-1 + TOUCHPAD_DATA_OFFSET + reportOffset + touchOffset];
+                        cState.TouchPacketCounter = inputReport[8 + TOUCHPAD_DATA_OFFSET + reportOffset + touchOffset];
                         cState.Touch1 = (inputReport[0 + TOUCHPAD_DATA_OFFSET + reportOffset + touchOffset] >> 7) != 0 ? false : true; // finger 1 detected
                         cState.Touch1Identifier = (byte)(inputReport[0 + TOUCHPAD_DATA_OFFSET + reportOffset + touchOffset] & 0x7f);
                         cState.Touch2 = (inputReport[4 + TOUCHPAD_DATA_OFFSET + reportOffset + touchOffset] >> 7) != 0 ? false : true; // finger 2 detected


### PR DESCRIPTION
This fixes the Touchpad Passthru function when using a DualSense controller.

Basically, there was:

- 1 typo
- A incorrect value used as offset
    - Probably a bad copy-pasta. On the DS4 the TP frame counter is _before_ the actual main finger states info, so the value of -1 was used as offset. On the DualSense's Input report its equivalent data (a TP timestamp) is _after_ both fingers data